### PR TITLE
Remove fusion-plugin-universal-events registration

### DIFF
--- a/templates/basic/content/package.json
+++ b/templates/basic/content/package.json
@@ -7,7 +7,6 @@
     "fusion-core": "^1.3.1",
     "fusion-plugin-react-router": "^1.1.1",
     "fusion-plugin-styletron-react": "^2.4.1",
-    "fusion-plugin-universal-events": "^1.0.5",
     "fusion-react": "^1.0.5",
     "fusion-react-async": "^1.2.2",
     "fusion-tokens": "^1.0.3",

--- a/templates/basic/content/src/main.js
+++ b/templates/basic/content/src/main.js
@@ -1,9 +1,6 @@
 // @flow
 import App from 'fusion-react';
 import Router from 'fusion-plugin-react-router';
-import UniversalEvents, {
-  UniversalEventsToken,
-} from 'fusion-plugin-universal-events';
 import Styletron from 'fusion-plugin-styletron-react';
 
 import root from './root.js';
@@ -12,6 +9,5 @@ export default () => {
   const app = new App(root);
   app.register(Styletron);
   app.register(Router);
-  app.register(UniversalEventsToken, UniversalEvents);
   return app;
 };


### PR DESCRIPTION
Closes #14 

## Description

By removing the `UniversalEvents` plugin registration the default creation template now runs without any errors.

## Other

The `"fusion-plugin-universal-events": "^1.0.5",` entry in `package.json` isn't visible in the current version of `create-fusion-app` in the public registry.  Not sure if that's on purpose or if a publish was missing.

Either way, it's now removed!