### PR TITLE
Use proper path separator for OS

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,7 +23,7 @@ Example:
 
 console.log(`
 Creating a new Fusion.js app in: ${chalk.green(
-  `${process.cwd()}/${projectName}`
+  `${process.cwd()}${path.sep}${projectName}`
 )}
 `);
 


### PR DESCRIPTION
On Windows machines, the log currently says "Creating a new Fusion.js app in C:\dev/fusion-app", which should be a backslash.