### PR TITLE
Add build-production target to match documentation

### DIFF
--- a/templates/basic/content/package.json
+++ b/templates/basic/content/package.json
@@ -19,6 +19,7 @@
     "dev": "fusion dev",
     "test": "fusion test",
     "build": "fusion build",
+    "build-production": "fusion build --production",
     "start": "fusion start"
   },
   "devDependencies": {


### PR DESCRIPTION
Our documentation currently recommends using  after scaffolding, but it's missing from package.json. Adding it here for consistency.